### PR TITLE
Fix popup confirmation on a newly added section not saved to the page

### DIFF
--- a/lib/src/components/Sections/index.vue
+++ b/lib/src/components/Sections/index.vue
@@ -3584,7 +3584,9 @@ export default {
 	  this.originalVariations = JSON.parse(
 		   JSON.stringify(this.displayVariations)
 	  );
-
+	  if (this.displayVariations[this.selectedVariation].views[this.currentSection.id] === undefined) {
+		delete this.displayVariations[this.selectedVariation].views[this.currentSection.id]
+	  }
 	  this.currentViews = this.displayVariations[this.selectedVariation].views;
 	}
   }


### PR DESCRIPTION
Fix popup confirmation on a newly added section not saved to the page