### PR TITLE
V.1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the new introduced component to display the wysiwyg content
 `<gWysiwygContent :html-content="html" />`
 
+### Added
+
+- Inject transpile quill 2 support in host project from module.js, required to have quill v2 working
+
+
 ### [1.0.18] - 2025-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for dynamic default language configured from Sections BO: Changes needed to make nuxt sections library able of configuring the defaultlocale of the nuxt/i18n library configuration #112
 
+- Metatag adjustments #149
+
+
 ### [1.0.18] - 2025-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inject transpile quill 2 support in host project from module.js, required to have quill v2 working
 
+- Tooltip copied message when anchor is clicked: Make sure that when you copy the anchor of a section there is a message copied to the clipboard #148
+
 
 ### [1.0.18] - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.0] - 2025-03-17
+
+### Removed
+
+- Optimization update: Global css import for quill editor is moved to the form and view components to only load the css when the components are used
+
+**Breaking Change**
+- Using `v-html` to display the wysiwyg content will still work, but it will no more have the wysiwyg styles `headings, aligments etc...`
+- Use the new introduced component to display the wysiwyg content
+`<gWysiwygContent :html-content="html" />`
+
 ### [1.0.18] - 2025-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tooltip copied message when anchor is clicked: Make sure that when you copy the anchor of a section there is a message copied to the clipboard #148
 
+- Support for dynamic default language configured from Sections BO: Changes needed to make nuxt sections library able of configuring the defaultlocale of the nuxt/i18n library configuration #112
 
 ### [1.0.18] - 2025-03-06
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -601,6 +601,14 @@ module.exports = async function (moduleOptions) {
     }
   }
 
+  try {
+    this.options.build = this.options.build || {}
+    this.options.build.transpile = this.options.build.transpile || []
+    if (!this.options.build.transpile.includes('quill')) {
+      this.options.build.transpile.push('quill')
+    }
+  } catch {}
+
   this.addModule('@geeks.solutions/vue-components/nuxt');
   this.options.css.push('@geeks.solutions/vue-components/assets/icons/icomoon/style.css')
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -141,6 +141,8 @@ module.exports = async function (moduleOptions) {
         "filterClear": "Clear",
         "filterBy": "Filter by:",
         "sectionsAppName": "Application name",
+        "anchorCopied":"Copied to clipboard",
+        "copyAnchorFailed":"Copy failed! For security reasons, this feature only works on a secure website",
         "mediaComponent": {
           "Upload":"Attach a media",
           "Change": "Modify your media",
@@ -413,6 +415,8 @@ module.exports = async function (moduleOptions) {
         "filterClear": "Effacer",
         "filterBy": "Filtrer par:",
         "sectionsAppName": "Nom d'application",
+        "anchorCopied":"Copié dans le presse-papiers",
+        "copyAnchorFailed":"Échec de la copie ! Pour des raisons de sécurité, cette fonctionnalité fonctionne uniquement sur un site sécurisé",
         "mediaComponent": {
           "Upload":"Attacher un média",
           "Change": "Modifier votre média",

--- a/lib/module.js
+++ b/lib/module.js
@@ -603,10 +603,6 @@ module.exports = async function (moduleOptions) {
 
   this.addModule('@geeks.solutions/vue-components/nuxt');
   this.options.css.push('@geeks.solutions/vue-components/assets/icons/icomoon/style.css')
-  this.addPlugin({
-    src: require.resolve('@geeks.solutions/vue-components/plugins/quill-editor.js'),
-    mode: 'client',
-  });
 
 
   let cookiesAlias = 'cookies'

--- a/lib/src/components/Sections/index.vue
+++ b/lib/src/components/Sections/index.vue
@@ -1851,7 +1851,7 @@ export default {
       if (optionsRes.status === 200) {
         try {
           const res = await this.$axios.post(URL, payload, config)
-          this.initializeSections(res, true);
+          this.initializeSections(res);
         } catch (error)  {
           const pagePath = `/${decodeURIComponent(this.$route.params.pathMatch ? this.$route.params.pathMatch : '/')}`
           if (error.response && error.response.data && error.response.status && error.response.status === 404 && error.response.data.options && error.response.data.options.project_metadata && error.response.data.options.project_metadata.pagePath404 && error.response.data.options.project_metadata.pagePath404 !== '' && error.response.data.options.project_metadata.pagePath404 !== pagePath && !this.$cookies.get("sections-auth-token")) {
@@ -1860,7 +1860,7 @@ export default {
           }
           if (error.response.status === 400) {
             const res = error.response;
-            this.initializeSections(res, true);
+            this.initializeSections(res);
             return;
           }
           if (error.response.status === 404) {
@@ -1904,7 +1904,7 @@ export default {
   },
   methods: {
     parsePath,
-    initializeSections(res, onServer) {
+    initializeSections(res) {
       this.$nuxt.$emit('page_pre_render', res)
       const sections = res.data.sections;
       this.pageData = res.data;
@@ -1931,28 +1931,9 @@ export default {
         this.$set(this.projectMetadata, 'languages', res.data.metadata.project_metadata.languages)
         this.selectedLanguages = res.data.metadata.project_metadata.languages
       }
-      let path = ""
-      if (this.$route.params) {
-        path = `${this.$route.params.pathMatch ? `/${this.$route.params.pathMatch}` : '/'}`
-      }
       if (res.data.metadata.project_metadata && res.data.metadata.project_metadata.defaultLang) {
         this.$set(this.projectMetadata, 'defaultLang', res.data.metadata.project_metadata.defaultLang)
         this.defaultLang = res.data.metadata.project_metadata.defaultLang
-        try {
-          if (this.$sections.cname === "active" && this.selectedLanguages.length === 1 && !this.$route.fullPath.startsWith(`/${this.selectedLanguages[0]}/`)) {
-            this.defaultLang = this.selectedLanguages[0]
-            this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
-          } else if (this.defaultLang && this.$sections.cname === "active" && onServer && !this.locales.some(locale => this.$route.fullPath.startsWith(`/${locale}/`))) {
-            this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
-          }
-        } catch {}
-      } else if (this.$sections.cname === "active") {
-        if (this.selectedLanguages.length === 1 && !this.$route.fullPath.startsWith(`/${this.selectedLanguages[0]}/`)) {
-          this.defaultLang = this.selectedLanguages[0]
-          this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
-        } else if (this.$route.fullPath === '/') {
-          this.$nuxt.context.redirect({ path: `/en${path}`, query: this.$route.query })
-        }
       }
       if (res.data.metadata.project_metadata && res.data.metadata.project_metadata.activateCookieControl === true) {
         this.$set(this.projectMetadata, 'activateCookieControl', res.data.metadata.project_metadata.activateCookieControl, true)

--- a/lib/src/components/Sections/index.vue
+++ b/lib/src/components/Sections/index.vue
@@ -1151,16 +1151,28 @@
                           </div>
                         </div>
                         <div>
-                          <div class="sections-mt-2 sectionsFieldsLabels">
-                            {{ $t('CSS') }}
+                          <div>
+                            <div class="sections-mt-2 sectionsFieldsLabels">
+                              {{ $t('Image Metatag') }}
+                            </div>
+                            <UploadMedia :media-label="''" :upload-text="$t('mediaComponent.Upload')"
+                                         :change-text="$t('mediaComponent.Change')" :seo-tag="$t('mediaComponent.seoTag')"
+                                         :media="pageMetadata['mediaMetatag'] && Object.keys(pageMetadata['mediaMetatag']).length > 0 ? [pageMetadata['mediaMetatag']] : []"
+                                         @uploadContainerClicked="selectedMediaType = 'mediaMetatag'; $refs.sectionsMediaComponent.openModal(pageMetadata['mediaMetatag'] && Object.keys(pageMetadata['mediaMetatag']).length > 0 ? pageMetadata['mediaMetatag'].media_id : null)"
+                                         @removeUploadedImage="removeMedia('mediaMetatag')"/>
                           </div>
-                          <UploadMedia :is-document="true" :media-label="''" :upload-text="$t('mediaComponent.Upload')"
-                                       :change-text="$t('mediaComponent.Change')" :seo-tag="$t('mediaComponent.seoTag')"
-                                       :media="pageMetadata['media'] && Object.keys(pageMetadata['media']).length > 0 ? [pageMetadata['media']] : []"
-                                       @uploadContainerClicked="selectedMediaType = 'media'; $refs.sectionsMediaComponent.openModal(pageMetadata['media'] && Object.keys(pageMetadata['media']).length > 0 ? pageMetadata['media'].media_id : null, 'document')"
-                                       @removeUploadedImage="removeMedia('media')"/>
-                          <MediaComponent ref="sectionsMediaComponent" :sections-user-id="sectionsUserId"
-                                          @emittedMedia="(mediaObject) => selectedCSS(mediaObject, selectedMediaType)"></MediaComponent>
+                          <div>
+                            <div class="sections-mt-2 sectionsFieldsLabels">
+                              {{ $t('CSS') }}
+                            </div>
+                            <UploadMedia :is-document="true" :media-label="''" :upload-text="$t('mediaComponent.Upload')"
+                                         :change-text="$t('mediaComponent.Change')" :seo-tag="$t('mediaComponent.seoTag')"
+                                         :media="pageMetadata['media'] && Object.keys(pageMetadata['media']).length > 0 ? [pageMetadata['media']] : []"
+                                         @uploadContainerClicked="selectedMediaType = 'media'; $refs.sectionsMediaComponent.openModal(pageMetadata['media'] && Object.keys(pageMetadata['media']).length > 0 ? pageMetadata['media'].media_id : null, 'document')"
+                                         @removeUploadedImage="removeMedia('media')" />
+                            <MediaComponent ref="sectionsMediaComponent" :sections-user-id="sectionsUserId"
+                                            @emittedMedia="(mediaObject) => selectedCSS(mediaObject, selectedMediaType)"></MediaComponent>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1381,14 +1393,31 @@ export default {
     }
   },
   head() {
+    const baseURL = process.server
+      ? (this.$nuxt.context.req.headers['x-forwarded-proto'] || 'http') + '://' + this.$nuxt.context.req?.headers.host
+      : window.location.origin;
+
+    const fullURL = baseURL + this.$route.fullPath;
+
     return {
+      htmlAttrs: {
+        title: this.computedTitle
+      },
       title: this.computedTitle,
       meta: [
         {
           hid: 'description',
           name: 'description',
           content: this.computedDescription
-        }
+        },
+        { hid: "og:title", property: "og:title", content: this.computedTitle },
+        { hid: "og:description", property: "og:description", content: this.computedDescription },
+        this.pageMetadata['mediaMetatag'] && this.pageMetadata['mediaMetatag'].url ? {
+          hid: "og:image",
+          property: "og:image",
+          content: this.pageMetadata['mediaMetatag'].url
+        } : {},
+        { hid: "og:url", property: "og:url", content: fullURL },
       ],
       link: [
         this.projectMetadata['selectedCSSPreset'] && this.projectMetadata['selectedCSSPreset'].name && this.projectMetadata['selectedCSSPreset'].name !== 'Other' && this.projectMetadata['selectedCSSPreset'].name !== 'None' ? {
@@ -1931,6 +1960,9 @@ export default {
       }
       if (res.data.metadata.media) {
         this.$set(this.pageMetadata, 'media', res.data.metadata.media)
+      }
+      if (res.data.metadata.mediaMetatag) {
+        this.$set(this.pageMetadata, 'mediaMetatag', res.data.metadata.mediaMetatag)
       }
       this.computedTitle = this.pageMetadata[this.lang].title
       this.computedDescription = this.pageMetadata[this.lang].description

--- a/lib/src/components/Sections/index.vue
+++ b/lib/src/components/Sections/index.vue
@@ -876,7 +876,7 @@
                       <TrashIcon class="trash-icon"/>
                     </div>
                     <div
-                      @click="copyAnchor((view.linked_to !== '' && view.linked_to !== undefined) ? `#${view.linked_to}-${view.id}` : `#${view.name}-${view.id}`)">
+                      @click="copyAnchor((view.linked_to !== '' && view.linked_to !== undefined) ? `#${view.linked_to}-${view.id}` : `#${view.name}-${view.id}`, $event)">
                       <AnchorIcon
                         :title="(view.linked_to !== '' && view.linked_to !== undefined) ? `Anchor id: #${view.linked_to}-${view.id}, ${$t('clickToCopy')}` : `Anchor id: #${view.name}-${view.id}, ${$t('clickToCopy')}`"
                         class="edit-icon"/>
@@ -975,7 +975,7 @@
                               <TrashIcon class="trash-icon"/>
                             </div>
                             <div
-                              @click="copyAnchor((view.linked_to !== '' && view.linked_to !== undefined) ? `#${view.linked_to}-${view.id}` : `#${view.name}-${view.id}`)">
+                              @click="copyAnchor((view.linked_to !== '' && view.linked_to !== undefined) ? `#${view.linked_to}-${view.id}` : `#${view.name}-${view.id}`, $event)">
                               <AnchorIcon
                                 :title="(view.linked_to !== '' && view.linked_to !== undefined) ? `Anchor id: #${view.linked_to}-${view.id}, ${$t('clickToCopy')}` : `Anchor id: #${view.name}-${view.id}, ${$t('clickToCopy')}`"
                                 class="edit-icon"/>
@@ -3942,8 +3942,33 @@ export default {
       );
       this.computeLayoutData();
     },
-    copyAnchor(anchor) {
-      navigator.clipboard.writeText(anchor);
+    copyAnchor(anchor, event) {
+      try {
+        if (window.location.protocol.replace(':', '') === 'http') {
+          console.log("Got here", window.location.protocol)
+          this.showToast("", "error", this.$t('copyAnchorFailed'));
+          return
+        }
+
+        navigator.clipboard.writeText(anchor);
+
+        const tooltip = document.createElement("div");
+        tooltip.innerText = this.$t("anchorCopied");
+        tooltip.className =
+          "anchor-copied-tooltip";
+        document.body.appendChild(tooltip);
+        tooltip.style.left = `${event.clientX}px`;
+        tooltip.style.top = `${event.clientY}px`;
+        setTimeout(() => {
+          tooltip.classList.add("copied-opacity-100");
+        }, 10);
+        setTimeout(() => {
+          tooltip.classList.remove("copied-opacity-100");
+          setTimeout(() => tooltip.remove(), 300);
+        }, 1500);
+      } catch {
+        this.showToast("", "error", this.$t('copyAnchorFailed'));
+      }
     },
     errorAddingSection(error) {
       this.isModalOpen = !error.closeModal;
@@ -5706,5 +5731,23 @@ span.handle {
 }
 section .ql-editor.ql-snow.grey-bg {
   background: grey;
+}
+.copied-opacity-100 {
+  opacity: 1 !important;
+}
+.anchor-copied-tooltip {
+  position: fixed;
+  background-color: #31a9db;
+  color: white;
+  font-size: 0.75rem;
+  padding: 0.5rem 0.5rem;
+  border-radius: 0.25rem;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  z-index: 50;
+  transform: translate(-100%, -100%);
+  pointer-events: none;
+  white-space: nowrap;
 }
 </style>

--- a/lib/src/components/Sections/index.vue
+++ b/lib/src/components/Sections/index.vue
@@ -1902,21 +1902,28 @@ export default {
         this.$set(this.projectMetadata, 'languages', res.data.metadata.project_metadata.languages)
         this.selectedLanguages = res.data.metadata.project_metadata.languages
       }
+      let path = ""
+      if (this.$route.params) {
+        path = `${this.$route.params.pathMatch ? `/${this.$route.params.pathMatch}` : '/'}`
+      }
       if (res.data.metadata.project_metadata && res.data.metadata.project_metadata.defaultLang) {
         this.$set(this.projectMetadata, 'defaultLang', res.data.metadata.project_metadata.defaultLang)
         this.defaultLang = res.data.metadata.project_metadata.defaultLang
         try {
-          if (this.defaultLang && this.$sections.cname === "active" && onServer && !this.$cookies.get('sections-default-lang')) {
-            this.$cookies.set('sections-default-lang', this.defaultLang)
-            let path = ""
-            if (this.$route.params) {
-              path = `/${this.$route.params.pathMatch ? this.$route.params.pathMatch : '/'}`
-            }
-            this.$nuxt.context.redirect({ path: this.$nuxt.localePath(path, this.defaultLang), query: this.$route.query })
-          } else if (this.defaultLang && this.$sections.cname === "active" && onServer) {
-            this.$cookies.set('sections-default-lang', this.defaultLang)
+          if (this.$sections.cname === "active" && this.selectedLanguages.length === 1 && !this.$route.fullPath.startsWith(`/${this.selectedLanguages[0]}/`)) {
+            this.defaultLang = this.selectedLanguages[0]
+            this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
+          } else if (this.defaultLang && this.$sections.cname === "active" && onServer && !this.locales.some(locale => this.$route.fullPath.startsWith(`/${locale}/`))) {
+            this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
           }
         } catch {}
+      } else if (this.$sections.cname === "active") {
+        if (this.selectedLanguages.length === 1 && !this.$route.fullPath.startsWith(`/${this.selectedLanguages[0]}/`)) {
+          this.defaultLang = this.selectedLanguages[0]
+          this.$nuxt.context.redirect({ path: `/${this.defaultLang}${path}`, query: this.$route.query })
+        } else if (this.$route.fullPath === '/') {
+          this.$nuxt.context.redirect({ path: `/en${path}`, query: this.$route.query })
+        }
       }
       if (res.data.metadata.project_metadata && res.data.metadata.project_metadata.activateCookieControl === true) {
         this.$set(this.projectMetadata, 'activateCookieControl', res.data.metadata.project_metadata.activateCookieControl, true)

--- a/lib/src/configs/views/wysiwyg_static.vue
+++ b/lib/src/configs/views/wysiwyg_static.vue
@@ -4,9 +4,7 @@
     :class="html && html.length > 2 ? 'mtitle' + html.charAt(2) : 'mtitle'"
     v-if="html"
   >
-    <div class="ql-editor ql-snow" :class="[{ 'slide-up': isVisible }, cssClasses]">
-      <div v-html="html" />
-    </div>
+    <gWysiwygContent tag="div" :wrapper-classes="`${isVisible ? 'slide-up' : ''} ${cssClasses}`" :html-content="html" />
   </div>
 </template>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geeks.solutions/nuxt-sections",
-  "version": "1.0.18",
+  "version": "1.1.0",
   "author": "Geeks Solutions info@geeks.solutions (https://www.geeks.solutions)",
   "repository": {
     "type": "git",
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@geeks.solutions/vue-components": "^1.0.12",
+    "@geeks.solutions/vue-components": "geeks.solutions-vue-components-1.0.13.tgz",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/i18n": "^7.3.1",
     "cookie-universal-nuxt": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@geeks.solutions/vue-components": "geeks.solutions-vue-components-1.0.13.tgz",
+    "@geeks.solutions/vue-components": "^1.0.13",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/i18n": "^7.3.1",
     "cookie-universal-nuxt": "^2.2.2",

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -5,6 +5,7 @@ import WysiwygStatic from '../lib/src/configs/views/wysiwyg_static.vue';
 
 describe('SectionsMain', () => {
   let controlsWrapper;
+  let tooltip;
 
   beforeEach(() => {
     controlsWrapper = shallowMount(SectionsMain, {
@@ -13,6 +14,7 @@ describe('SectionsMain', () => {
         $sections: {
           cname: true
         },
+        showToast: jest.fn()
       },
       propsData: {
         admin: true,
@@ -53,6 +55,17 @@ describe('SectionsMain', () => {
         };
       },
     });
+
+    global.navigator.clipboard = {
+      writeText: jest.fn(),
+    };
+    delete window.location;
+    window.location = { protocol: 'https:' };
+    tooltip = document.createElement('div');
+    tooltip.className = 'anchor-copied-tooltip';
+    tooltip.style.left = '100px';
+    tooltip.style.top = '200px';
+    document.body.appendChild = jest.fn().mockImplementation(() => tooltip);
   });
 
   test('calls initializeSections and computeLayoutData in fetch()', async () => {
@@ -773,6 +786,28 @@ describe('SectionsMain', () => {
     })
   });
 
+  it('Copy anchor should display the tooltip with correct styles when copyAnchor is called', async () => {
+    const anchor = 'http://example.com';  // Example anchor to copy
+    const event = { clientX: 100, clientY: 200 }; // Example mouse event
+
+    await controlsWrapper.vm.copyAnchor(anchor, event);
+
+    expect(document.body.appendChild).toHaveBeenCalled();
+
+    expect(document.body.appendChild).toHaveBeenCalledWith(expect.objectContaining({
+      className: 'anchor-copied-tooltip',
+      style: expect.objectContaining({
+        left: '100px',
+        top: '200px',
+      }),
+    }));
+
+    jest.advanceTimersByTime(10);
+
+    expect(tooltip.style.left).toBe('100px');
+    expect(tooltip.style.top).toBe('200px');
+  });
+
 })
 
 describe('Types tests', () => {
@@ -1226,9 +1261,6 @@ describe("WysiwygStatic", () => {
         lang: "en",
       },
     });
-
-    // Check if the element with .ql-snow and .ql-editor classes exists
-    expect(wrapper.find(".ql-snow .ql-editor").exists()).toBe(true);
   });
-  
+
 });


### PR DESCRIPTION
- [ ] Optimization update: Global css import for quill editor is moved to the form and view components to only load the css when the components are used
- [ ] Inject transpile quill 2 support in host project from module.js, required to have quill v2 working
- [ ] Changes needed to make nuxt sections library able of configuring the defaultlocale of the nuxt/i18n library configuration #112
- [ ] Changes needed to make nuxt sections library able of configuring the defaultlocale of the nuxt/i18n library configuration #112
- [ ] Metatag adjustments #149